### PR TITLE
fix check right on model

### DIFF
--- a/front/model.php
+++ b/front/model.php
@@ -33,7 +33,7 @@ include ('../../../inc/includes.php');
 Html::header(PluginUninstallModel::getTypeName(Session::getPluralNumber()), '', "admin",
    "PluginUninstallModel", "model");
 
-if (Session::haveRight(PluginUninstallProfile::$rightname, READ)) {
+if (Session::haveRight(PluginUninstallModel::$rightname, READ)) {
    Search::show("PluginUninstallModel");
 } else {
    Html::displayRightError();


### PR DESCRIPTION
PluginUninstallModel Class use rightname 'uninstall:profil'

But model.php in front folder check PluginUninstallProfile rightname which is 'profile'

Therefore a user with the right to read / modify can not access the model

This PR prevent this

