### PR TITLE
Add GLPI 9.5 compatibility

### DIFF
--- a/ajax/dropdownReplaceFindDevice.php
+++ b/ajax/dropdownReplaceFindDevice.php
@@ -104,7 +104,7 @@ $query = "SELECT *
           ORDER BY `name`
           $LIMIT";
 $result = $DB->query($query);
-while ($data = $DB->fetch_assoc($result)) {
+while ($data = (method_exists($DB, 'fetchAssoc') ? $DB->fetchAssoc($result) : $DB->fetch_assoc($result))) {
    $outputval = Toolbox::unclean_cross_side_scripting_deep($data["name"]);
 
    if ($displaywith) {

--- a/inc/replace.class.php
+++ b/inc/replace.class.php
@@ -887,7 +887,8 @@ class PluginUninstallReplace extends CommonDBTM {
       foreach ($UNINSTALL_DIRECT_CONNECTIONS_TYPE as $itemtype) {
          $item = new $itemtype();
          if ($item->canView()) {
-            $datas = getAllDatasFromTable('glpi_computers_items',
+            $getAllFct = function_exists('getAllDataFromTable') ? 'getAllDataFromTable' : 'getAllDatasFromTable';
+            $datas = $getAllFct('glpi_computers_items',
                                           ['computers_id' => $ID, 'itemtype' => $itemtype]);
             foreach ($datas as $computer_item) {
                $data[$itemtype][] = $computer_item;

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -218,6 +218,8 @@ class PluginUninstallUninstall extends CommonDBTM {
             }
 
             if ($item->isField('domains_id') && $model->fields["raz_domain"]) {
+               // 'domains_id' field has been replaced in GLPI 9.5 by an entry in glpi_domains_items
+               // this piece of code could be removed when plugin will not be anymore compatible with GLPI < 9.5
                $fields["domains_id"] = 0;
             }
 
@@ -259,6 +261,11 @@ class PluginUninstallUninstall extends CommonDBTM {
                $infocom->dohistory = false;
                $infocom->update($tmp);
             }
+         }
+
+         if ($model->fields["raz_domain"]) {
+            $domain_item = new Domain_Item();
+            $domain_item->cleanDBonItemDelete($type, $id);
          }
 
          //Delete machine from glpi_ocs_link

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -795,7 +795,7 @@ class PluginUninstallUninstall extends CommonDBTM {
                 ORDER BY `name`";
       $result = $DB->query($query);
 
-      while ($datas = $DB->fetch_array($result)) {
+      while ($datas = method_exists($DB, 'fetchArray') ? $DB->fetchArray($result) : $DB->fetch_array($result)) {
          $templates[$datas["id"]] = ($add_entity
                                        ? Dropdown::getDropdownName("glpi_entities",
                                                                    $datas["entities_id"]) . " > "

--- a/setup.php
+++ b/setup.php
@@ -33,7 +33,7 @@ define ('PLUGIN_UNINSTALL_VERSION', '2.6.3');
 // Minimal GLPI version, inclusive
 define("PLUGIN_UNINSTALL_MIN_GLPI", "9.3");
 // Maximum GLPI version, exclusive
-define("PLUGIN_UNINSTALL_MAX_GLPI", "9.5");
+define("PLUGIN_UNINSTALL_MAX_GLPI", "9.6");
 
 /**
  * Function Init


### PR DESCRIPTION
With this PR, plugin should be compatible with GLPI 9.5.

Some enhancements could be done but not necessarily as part of this PR:
1. Adding icons for menu entries provided by `CommonGLPI::getMenuContent()` overrides.
2. Adding the ability to define a strategy for `glpi_impactrelations` data.