### PR TITLE
Drop invalid PDF version check; fixes #60

### DIFF
--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -414,8 +414,7 @@ class PluginUninstallModel extends CommonDBTM {
       echo "</td>";
       echo "<td>";
       $plug = new Plugin();
-      if ($plug->isActivated('PDF')
-          && $plug->fields['version'] >= '0.7.1') {
+      if ($plug->isActivated('PDF')) {
          echo "<span class='green b tracking_small'>".
                 __('Plugin PDF is installed and activated', 'uninstall')."</span>";
       } else {


### PR DESCRIPTION
`$plug->isActivated()` does not load corresponding fields, so checking `$plug->fields['version'] >= '0.7.1'` will always return false. Anyway, this `0.7.1` version is not used for years, and can probably be not even loaded in GLPI 9.5, so this check is useless now.