### PR TITLE
Fix display preferences

### DIFF
--- a/inc/preference.class.php
+++ b/inc/preference.class.php
@@ -86,6 +86,11 @@ class PluginUninstallPreference extends CommonDBTM {
             echo "<td>";
             $value = (isset($this->fields["locations_id"]) ? $this->fields["locations_id"] : 0);
 
+            // Handle "old" special value, dropdown expect "-1" in this case
+            if ($this->fields['locations_action'] == "old" && $value == 0) {
+               $value = -1;
+            }
+
             Location::dropdown(['name'      => "id[$pref_ID][locations_id]",
                                 'value'     => ($value == '' ? 0 : $value),
                                 'comments'  => 1,


### PR DESCRIPTION
Following https://github.com/pluginsGLPI/uninstall/commit/5e06ae757a7477980a98f3d4134c16884fff1345, the code to display preferences wasn't updated accordingly to handle the new `set`/`old` case.

![image](https://user-images.githubusercontent.com/42734840/194082015-019d9325-fe5b-4bde-a4a7-732a74082c80.png)

![image](https://user-images.githubusercontent.com/42734840/194082088-80e594cc-4177-49ac-88aa-567a1910dac9.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/194082127-ddde003e-b41e-4507-97f6-9ca01ed1ee17.png)
