### PR TITLE
feat(uninstall): delete inventory data

### DIFF
--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -376,6 +376,12 @@ class PluginUninstallModel extends CommonDBTM {
       Dropdown::showYesNo("raz_antivirus",
                           (isset($this->fields["raz_antivirus"])
                            ? $this->fields["raz_antivirus"] : 1));
+      echo "</td>";
+      echo "<td>" . __('Delete inventory data (Lock, Agent, Collect ...)', 'uninstall') . "</td>";
+      echo "<td>";
+      Dropdown::showYesNo("raz_glpiinventory",
+                           (isset($this->fields["raz_glpiinventory"])
+                           ? $this->fields["raz_glpiinventory"] : 0), -1);
       echo "</td></tr>";
    }
 
@@ -533,7 +539,6 @@ class PluginUninstallModel extends CommonDBTM {
                            ? $this->fields["replace_contact_num"] : 1),
                            -1, ['width' => '100%']);
       echo "</td>";
-      echo "<td colspan='2'></td>";
       echo "</tr>";
 
    }
@@ -1194,6 +1199,10 @@ class PluginUninstallModel extends CommonDBTM {
             );
          }
 
+         if (!$DB->fieldExists($table, 'raz_glpiinventory')) {
+            $migration->addField($table, 'raz_glpiinventory', "integer");
+         }
+
          $migration->migrationOneTable($table);
 
       } else {
@@ -1238,6 +1247,7 @@ class PluginUninstallModel extends CommonDBTM {
                     `replace_direct_connections` tinyint NOT NULL DEFAULT '0',
                     `overwrite` tinyint NOT NULL DEFAULT '0',
                     `replace_method` int NOT NULL DEFAULT '2',
+                    `raz_glpiinventory` int NOT NULL DEFAULT '1',
                     `raz_fusioninventory` int NOT NULL DEFAULT '1',
                     `raz_plugin_fields` tinyint NOT NULL DEFAULT '1',
                     `replace_contact` tinyint NOT NULL DEFAULT '0',
@@ -1298,6 +1308,7 @@ class PluginUninstallModel extends CommonDBTM {
          $tmp['raz_budget']                 = 1;
          $tmp['raz_user']                   = 1;
          $tmp['raz_ocs_registrykeys']       = 1;
+         $tmp['raz_glpiinventory']          = 1;
          $tmp['raz_fusioninventory']        = 1;
          $tmp['raz_plugin_fields']          = 1;
          $tmp['comment']                    = '';

--- a/inc/model.class.php
+++ b/inc/model.class.php
@@ -377,7 +377,7 @@ class PluginUninstallModel extends CommonDBTM {
                           (isset($this->fields["raz_antivirus"])
                            ? $this->fields["raz_antivirus"] : 1));
       echo "</td>";
-      echo "<td>" . __('Delete inventory data (Lock, Agent, Collect ...)', 'uninstall') . "</td>";
+      echo "<td>" . __('Delete inventory data (Dynamic flag, Lock, Agent, Collect ...)', 'uninstall') . "</td>";
       echo "<td>";
       Dropdown::showYesNo("raz_glpiinventory",
                            (isset($this->fields["raz_glpiinventory"])

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -511,7 +511,7 @@ class PluginUninstallUninstall extends CommonDBTM {
     *
     * @return nothing
    **/
-   static function deleteGlpiInventoryLink(&$item) {
+   static function deleteGlpiInventoryLink($item) {
       global $DB;
 
       $plug = new Plugin();

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -598,7 +598,6 @@ class PluginUninstallUninstall extends CommonDBTM {
 
          //manage networkname
          foreach (array_keys($db_networkport) as $networkport_id) {
-            Toolbox::logError("update glpi_networknames on NetworkPort " . $networkport_id);
             $DB->update(
                "glpi_networknames",
                [

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -111,7 +111,6 @@ class PluginUninstallUninstall extends CommonDBTM {
        $input                = [];
        $input["id"]          = $id;
        $input["entities_id"] = $entity;
-       $input['is_dynamic']  = $item->fields['is_dynamic']; #to prevent locked field
        $fields               = [];
 
        //Hook to perform actions before item is being uninstalled
@@ -122,6 +121,8 @@ class PluginUninstallUninstall extends CommonDBTM {
        if ($model->fields['raz_glpiinventory'] == 1) {
          self::deleteGlpiInventoryLink($item);
        }
+       $input['is_dynamic']  = $item->fields['is_dynamic']; #to prevent locked field
+
        //--------------------//
        //Direct connections //
        //------------------//
@@ -510,7 +511,7 @@ class PluginUninstallUninstall extends CommonDBTM {
     *
     * @return nothing
    **/
-   static function deleteGlpiInventoryLink($item) {
+   static function deleteGlpiInventoryLink(&$item) {
       global $DB;
 
       $plug = new Plugin();

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -586,7 +586,7 @@ class PluginUninstallUninstall extends CommonDBTM {
             foreach ($fields as $field) {
                if (is_array($field)) {
                   // Relation based on 'itemtype'/'items_id' (polymorphic relationship)
-                  if ($item instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
+                  if ($sub_item instanceof IPAddress && in_array('mainitemtype', $field) && in_array('mainitems_id', $field)) {
                      // glpi_ipaddresses relationship that does not respect naming conventions
                      $itemtype_field = 'mainitemtype';
                      $items_id_field = 'mainitems_id';

--- a/setup.php
+++ b/setup.php
@@ -33,7 +33,7 @@ use Glpi\Plugin\Hooks;
 define ('PLUGIN_UNINSTALL_VERSION', '2.8.1');
 
 // Minimal GLPI version, inclusive
-define("PLUGIN_UNINSTALL_MIN_GLPI", "10.0.0");
+define("PLUGIN_UNINSTALL_MIN_GLPI", "10.0.7");
 // Maximum GLPI version, exclusive
 define("PLUGIN_UNINSTALL_MAX_GLPI", "10.0.99");
 


### PR DESCRIPTION
Adds an option to delete inventory data:
- unlock fields
- native agent
- elements linked to the agent if the `glpiinventory` plugin is active


ref: !25150