### PR TITLE
Fix check group entity

### DIFF
--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -187,7 +187,7 @@ class PluginUninstallUninstall extends CommonDBTM
             $nbgroup = countElementsInTableForEntity(
                 "glpi_groups",
                 $entity,
-                ['id' => $item->fields['groups_id']]
+                ['id' => $model->fields['groups_id']]
             );
             if (
                 ($model->fields["groups_action"] === 'set')


### PR DESCRIPTION
It checks the entity of the group of the asset causing that if the asset did not have a group assigned it did not assign the new group of the configuration.
Now it checks the entity of the group to be assigned.