### PR TITLE
bugfix : uninstall model doesn't set groups_id to 0

### DIFF
--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -191,7 +191,7 @@ class PluginUninstallUninstall extends CommonDBTM
             );
             if (
                 ($model->fields["groups_action"] === 'set')
-                && ($nbgroup == 1)
+                && ($nbgroup == 1 || $model->fields["groups_id"] == 0)
             ) {
                 // If a new group is defined and if the group is accessible in the object's entity
                 $fields["groups_id"] = $model->fields["groups_id"];


### PR DESCRIPTION
Fix a bug where the set group action on a uninstall type model didn't work if the new value was 0.