### PR TITLE
Fix(Replace): Add missing left join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASE]
+
+### Fixed
+- Fix SQL error during replace tickets
+
 ## [2.9.3] - 2025-04-01
 
 ### Fixed

--- a/inc/replace.class.php
+++ b/inc/replace.class.php
@@ -990,6 +990,14 @@ class PluginUninstallReplace extends CommonDBTM
         $tickets = [];
         $it = $DB->request([
             'FROM' => 'glpi_items_tickets',
+            'JOIN'  => [
+                'glpi_tickets' => [
+                    'ON' => [
+                        'glpi_tickets' => 'id',
+                        'glpi_items_tickets' => 'ticket_id',
+                    ],
+                ],
+            ],
             'WHERE' => [
                 'itemtype' => $itemtype,
                 'items_id' => $items_id,


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #143 

This PR fixes an issue related to entity-based access restrictions when using `getEntitiesRestrictCriteria('glpi_tickets')`.

Currently, the method adds a `WHERE` clause such as:

```sql
(glpi_tickets.entities_id IN ('1'))
```

However, when executing a query like:

```sql
SELECT * FROM glpi_items_tickets 
WHERE itemtype = 'Printer' 
  AND items_id = '1161' 
  AND (glpi_tickets.entities_id IN ('1'))
```

It results in the following error:

```
Error: Unknown column 'glpi_tickets.entities_id' in 'where clause'
```

This happens because the query does not include a `LEFT JOIN` to the `glpi_tickets` table, which is necessary for the condition on `glpi_tickets.entities_id` to be valid.

**This PR ensures that the required `LEFT JOIN` on `glpi_tickets` is properly added when entity restrictions are applied, preventing SQL errors and ensuring expected filtering behavior.**



## Screenshots (if appropriate):
