### PR TITLE
Fix for changing the location of the equipment after uninstallation.

### DIFF
--- a/front/preference.form.php
+++ b/front/preference.form.php
@@ -38,7 +38,7 @@ if (isset($_POST['update_user_preferences_uninstall'])) {
     foreach ($_POST["id"] as $prefid => $values) {
         $pref = new PluginUninstallPreference();
         // load preferences and check if current user is the related user
-        if ($pref->getFromDB($_POST["id"]) && $pref->fields['users_id'] == Session::getLoginUserID()) {
+        if ($pref->getFromDB($values["id"]) && $pref->fields['users_id'] == Session::getLoginUserID()) {
             $pref->update($values);
         } else {
             Html::displayRightError("You don't have permission to perform this action");

--- a/inc/preference.class.php
+++ b/inc/preference.class.php
@@ -64,7 +64,6 @@ class PluginUninstallPreference extends CommonDBTM
             true,
         );
         $data       = plugin_version_uninstall();
-        $from = $this->getFormURL();
 
         echo "<form action='" . $this->getFormURL() . "' method='post'>";
         echo "<div class='center'>";

--- a/inc/preference.class.php
+++ b/inc/preference.class.php
@@ -30,7 +30,7 @@
 
 class PluginUninstallPreference extends CommonDBTM
 {
-    public static $rightname = "uninstall:replace";
+    public static $rightname = "uninstall:profile";
 
     public function prepareInputForAdd($input)
     {
@@ -64,6 +64,7 @@ class PluginUninstallPreference extends CommonDBTM
             true,
         );
         $data       = plugin_version_uninstall();
+        $from = $this->getFormURL();
 
         echo "<form action='" . $this->getFormURL() . "' method='post'>";
         echo "<div class='center'>";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38892
- Here is a brief description of what this PR does

Fixed an issue where it was not possible to change the location of equipment after uninstalling it in user preferences.

## Screenshots (if appropriate):
