### PR TITLE
Fix: Document already linked

### DIFF
--- a/inc/replace.class.php
+++ b/inc/replace.class.php
@@ -211,13 +211,27 @@ class PluginUninstallReplace extends CommonDBTM
             ) {
                 $doc_item = new Document_Item();
                 foreach (self::getAssociatedDocuments($olditem) as $document) {
-                    $doc_item->update(
-                        ['id'       => $document['assocID'],
-                            'itemtype' => $type,
-                            'items_id' => $newitem_id,
-                        ],
-                        false,
-                    );
+                    $existing = $doc_item->find([
+                        'documents_id' => $document['assocID'],
+                        'itemtype'     => $type,
+                        'items_id'     => $newitem_id,
+                    ]);
+                    if (empty($existing)) {
+                        $doc_item->update(
+                            [
+                                'id'       => $document['assocID'],
+                                'itemtype' => $type,
+                                'items_id' => $newitem_id,
+                            ],
+                            false,
+                        );
+                    } else {
+                        $doc_item->deleteByCriteria([
+                            'documents_id' => $document['assocID'],
+                            'itemtype'     => $type,
+                            'items_id'     => $olditem->getID(),
+                        ]);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39029

When the 'Copy documents' option is enabled, the plugin updates the links between documents and the old asset to associate them with the new asset. If the document is already linked to the new asset, an SQL error is raised.

```
glpisqllog.ERROR: DBmysql::doQuery() in .../src/DBmysql.php line 395
  *** MySQL query error:
  SQL: UPDATE glpi_documents_items SET documents_id = '126945' WHERE id = '188304'
  Error: Duplicate entry '126945-Computer-75322-0' for key 'unicity'
  Backtrace :
  src/DBmysql.php:1499                               DBmysql->doQuery()
  src/Transfer.php:2524                              DBmysql->update()
  src/Transfer.php:1279                              Transfer->transferDocuments()
  src/Transfer.php:270                               Transfer->transferItem()
  plugins/uninstall/inc/uninstall.class.php:304      Transfer->moveItems()
  plugins/uninstall/inc/uninstall.class.php:352      PluginUninstallUninstall::doOneUninstall()
  plugins/uninstall/front/action.php:81              PluginUninstallUninstall::uninstall()
  public/index.php:82                                require()

```

## Screenshots (if appropriate):
