### PR TITLE
2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+## [2.10.1] - 2025-10-24
+
 ### Fixed
 
 - Fix get associated items (move `glpi_computers_items` to `glpi_assets_assets_peripheralassets`)

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_UNINSTALL_VERSION', '2.10.0');
+define('PLUGIN_UNINSTALL_VERSION', '2.10.1');
 define("PLUGIN_UNINSTALL_MIN_GLPI", "11.0.0");
 define("PLUGIN_UNINSTALL_MAX_GLPI", "11.0.99");
 

--- a/uninstall.xml
+++ b/uninstall.xml
@@ -26,6 +26,11 @@
    </authors>
    <versions>
        <version>
+         <num>2.10.1</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/uninstall/releases/download/2.10.1/glpi-uninstall-2.10.1.tar.bz2</download_url>
+      </version>
+       <version>
          <num>2.10.0</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/uninstall/releases/download/2.10.0/glpi-uninstall-2.10.0.tar.bz2</download_url>


### PR DESCRIPTION
## [2.10.1] - 2025-10-24

### Fixed

- Fix get associated items (move `glpi_computers_items` to `glpi_assets_assets_peripheralassets`)