### PR TITLE
Fix: impossible to update Location preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix SQL error when copying documents already linked to the target asset.
+- Fix impossible to update Location preferences because table glpi_plugin_uninstall_profiles is droped.
 
 ## [2.9.4] - 2025-07-10
 

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -276,8 +276,6 @@ class PluginUninstallProfile extends Profile
             }
 
             self::migrateAllProfiles();
-
-            $migration->dropTable($table);
         } else {
             // plugin never installed
             $query = "CREATE TABLE `" . $table . "` (


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- It fixes issue #187 : It was impossible to update Location preferences because table glpi_plugin_uninstall_profiles is dropped in the install method when updating the plugin. 
- The solution was to remove the line that drops this table in this method and force plugin update with `php bin/console plugin:install uninstall --force` and `php bin/console plugin:activate uninstall`
