### PR TITLE
Fix: impossible to update Location preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix config redirection link
 - Fix plugin name display in marketplace
+- Fix impossible to update Location preferences because table glpi_plugin_uninstall_profiles is dropped.
 
 ## [2.10.2] - 2025-11-05
 

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -282,8 +282,6 @@ class PluginUninstallProfile extends Profile
             }
 
             self::migrateAllProfiles();
-
-            $migration->dropTable($table);
         } else {
             // plugin never installed
             $query = "CREATE TABLE `" . $table . "` (


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.


## Description

It fixes issue #187  : It was impossible to update Location preferences because table glpi_plugin_uninstall_profiles is dropped in the install method when updating the plugin.
The solution was to remove the line that drops this table in this method and force plugin update with `php bin/console plugin:install uninstall --force` and `php bin/console plugin:activate uninstall`


