### PR TITLE
FIX / Handle group assignment on uninstall templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix locales encoding
+- Fix group assignment when applying uninstall templates on assignable items
 
 ## [2.10.3] - 2025-11-25
 

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -29,6 +29,7 @@
  */
 
 use Glpi\Asset\Asset_PeripheralAsset;
+use Glpi\Features\AssignableItemInterface;
 
 use function Safe\preg_grep;
 
@@ -213,8 +214,10 @@ class PluginUninstallUninstall extends CommonDBTM
             }
         }
 
-        $can_update_groups = $item->isField('groups_id') || method_exists($item, 'prepareGroupFields');
-        if ($can_update_groups) {
+        if (
+            $item->isField('groups_id')
+            || ($item instanceof AssignableItemInterface)
+        ) {
             $nbgroup = countElementsInTableForEntity(
                 "glpi_groups",
                 $entity,

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -213,7 +213,8 @@ class PluginUninstallUninstall extends CommonDBTM
             }
         }
 
-        if ($item->isField('groups_id')) {
+        $can_update_groups = $item->isField('groups_id') || method_exists($item, 'prepareGroupFields');
+        if ($can_update_groups) {
             $nbgroup = countElementsInTableForEntity(
                 "glpi_groups",
                 $entity,


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43139
- Group assignment was not working due to a change on GLPI : the plugin now also supports items using GLPI's assignable group handling, instead of depending only on the legacy field detection.
