### PR TITLE
Fix - Asset_PeripheralAsset column names for GLPI 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix SQL errors when uninstalling or replacing peripheral assets
 - Fix locales encoding
 
 ## [2.10.3] - 2025-11-25

--- a/inc/replace.class.php
+++ b/inc/replace.class.php
@@ -451,9 +451,8 @@ class PluginUninstallReplace extends CommonDBTM
                     foreach (self::getAssociatedItems($olditem) as $itemtype => $connections) {
                         foreach ($connections as $connection) {
                             $comp_item->update(
-                                ['id'           => $connection['id'],
-                                    'computers_id' => $newitem_id,
-                                    'itemtype'     => $itemtype,
+                                ['id'             => $connection['id'],
+                                    'items_id_asset' => $newitem_id,
                                 ],
                                 false,
                             );

--- a/inc/replace.class.php
+++ b/inc/replace.class.php
@@ -448,7 +448,7 @@ class PluginUninstallReplace extends CommonDBTM
             ) { #do not update computer_item if no computer
                 $comp_item = new Asset_PeripheralAsset();
                 if ($olditem instanceof Computer) {
-                    foreach (self::getAssociatedItems($olditem) as $itemtype => $connections) {
+                    foreach (self::getAssociatedItems($olditem) as $connections) {
                         foreach ($connections as $connection) {
                             $comp_item->update(
                                 ['id'             => $connection['id'],

--- a/inc/uninstall.class.php
+++ b/inc/uninstall.class.php
@@ -164,8 +164,8 @@ class PluginUninstallUninstall extends CommonDBTM
         //------------------//
         if (in_array($type, $UNINSTALL_DIRECT_CONNECTIONS_TYPE)) {
             $conn = new Asset_PeripheralAsset();
-            $conn->deleteByCriteria(['itemtype' => $type,
-                'items_id' => $id,
+            $conn->deleteByCriteria(['itemtype_peripheral' => $type,
+                'items_id_peripheral' => $id,
             ], true);
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43188 & https://github.com/pluginsglpi/uninstall/issues/197
- Here is a brief description of what this PR does

Resolves SQL errors when uninstalling or replacing peripheral assets (Monitor, Peripheral, etc.)
Update plugin to use correct column names for the `glpi_assets_assets_peripheralassets` table in GLPI 11.x.

### Changes
- **Uninstall**: Use `itemtype_peripheral`/`items_id_peripheral` instead of deprecated `itemtype`/`items_id`
- **Replace**: Use `items_id_asset` instead of deprecated `computers_id` when updating peripheral asset connections